### PR TITLE
fix: Adjust errors in AreaRect class

### DIFF
--- a/Programs/AreaRect.java
+++ b/Programs/AreaRect.java
@@ -1,22 +1,14 @@
 // Program to calculate the area of rectangle using return values - 
-package area;
-class Rectangle {
-	public int l, b;
-	public void getData(int m, int n) {
-		l = m;
-		b = n;
-	}
-	public int calcArea() {
-		int area = l * b;
-		return area;
-	}
-}
+
 public class AreaRect {
 	public static void main(String[] args) {
+		
+		AreaRect areaRect = new AreaRect();
+		
 		// TODO Auto-generated method stub
 		int a1, a2;
-		Rectangle r1 = new Rectangle();
-		Rectangle r2 = new Rectangle();
+		Rectangle r1 = areaRect.new Rectangle();
+		Rectangle r2 = areaRect.new Rectangle();
 		r1.l = 10;
 		r1.b = 15;
 		a1 = r1.l * r1.b;
@@ -24,5 +16,17 @@ public class AreaRect {
 		a2 = r2.calcArea();
 		System.out.println("The area of first rectangle = " + a1);
 		System.out.println("The area of second rectangle = " + a2);
+	}
+	
+	public class Rectangle {
+		public int l, b;
+		public void getData(int m, int n) {
+			l = m;
+			b = n;
+		}
+		public int calcArea() {
+			int area = l * b;
+			return area;
+		}
 	}
 }

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It is very easy to contribute, you may follow these steps -
 
 ## Programs:
 1. [Abstract Class](https://github.com/PrajaktaSathe/Java/blob/main/Programs/abstractClass.java) - Program to demonstrate abstract classes in Java
-2. [Rectangle Area](https://github.com/PrajaktaSathe/Java/blob/main/Programs/areaRect.java) - Calculates area of a rectangle
+2. [Rectangle Area](https://github.com/PrajaktaSathe/Java/blob/main/Programs/AreaRect.java) - Calculates area of a rectangle
 3. [Arithmetic exceptions](https://github.com/PrajaktaSathe/Java/blob/main/Programs/arithExceptions.java) - Program to show Arithmetic Exception Error handling
 4. [Array Lists](https://github.com/PrajaktaSathe/Java/blob/main/Programs/arrayLists.java) - Program to show list of strings in java
 5. [Array Out Of Bounds](https://github.com/PrajaktaSathe/Java/blob/main/Programs/arrayOutOfBounds.java) - Program to show ArrayOutOfBoundsException Error handling


### PR DESCRIPTION
The class was showing an error due to the wrong name and because there were two classes at the root of the Java file.
Now the class is running in main method.